### PR TITLE
fix(v1): google use different callbacks to get token

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -100,6 +100,8 @@ login:
     client_id:
     client_secret:
     redirect_uri:
+      login:
+      bind:
   apple:
     enable: false
   agora:

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -95,6 +95,8 @@ login:
     client_id:
     client_secret:
     redirect_uri:
+      login:
+      bind:
   apple:
     enable: true
   agora:

--- a/src/utils/ParseConfig.ts
+++ b/src/utils/ParseConfig.ts
@@ -115,7 +115,10 @@ type Config = {
             enable: boolean;
             client_id: string;
             client_secret: string;
-            redirect_uri: string;
+            redirect_uri: {
+                login: string;
+                bind: string;
+            };
         };
         apple: {
             enable: boolean;

--- a/src/v1/controller/login/google/Callback.ts
+++ b/src/v1/controller/login/google/Callback.ts
@@ -48,7 +48,7 @@ export class GoogleCallback extends AbstractController<RequestType> {
 
         await LoginGoogle.assertHasAuthUUID(authUUID, this.logger);
 
-        const userInfo = await LoginGoogle.getUserInfoAndToken(code);
+        const userInfo = await LoginGoogle.getUserInfoAndToken("login", code);
 
         const userUUIDByDB = await ServiceUserGoogle.userUUIDByUnionUUID(userInfo.unionUUID);
 

--- a/src/v1/controller/login/platforms/LoginGoogle.ts
+++ b/src/v1/controller/login/platforms/LoginGoogle.ts
@@ -31,14 +31,17 @@ export class LoginGoogle extends AbstractLogin {
         });
     }
 
-    public static async getToken(code: string): Promise<string> {
+    public static async getToken(
+        route: keyof typeof Google.redirectURI,
+        code: string,
+    ): Promise<string> {
         const response = await ax.post<AccessToken>(
             "https://oauth2.googleapis.com/token",
             new URLSearchParams({
                 code,
                 client_id: Google.clientId,
                 client_secret: Google.clientSecret,
-                redirect_uri: Google.redirectURI,
+                redirect_uri: Google.redirectURI[route],
                 grant_type: "authorization_code",
             }),
         );
@@ -68,9 +71,10 @@ export class LoginGoogle extends AbstractLogin {
     }
 
     public static async getUserInfoAndToken(
+        route: keyof typeof Google.redirectURI,
         code: string,
     ): Promise<GoogleUserInfo & { accessToken: string }> {
-        const accessToken = await LoginGoogle.getToken(code);
+        const accessToken = await LoginGoogle.getToken(route, code);
         const userInfo = await LoginGoogle.getUserInfoByAPI(accessToken);
 
         return {

--- a/src/v1/controller/user/binding/platform/google/Binding.ts
+++ b/src/v1/controller/user/binding/platform/google/Binding.ts
@@ -59,7 +59,7 @@ export class BindingGoogle extends AbstractController<RequestType, any> {
             throw new ControllerError(ErrorCode.UnsupportedOperation);
         }
 
-        const userInfo = await LoginGoogle.getUserInfoAndToken(code);
+        const userInfo = await LoginGoogle.getUserInfoAndToken("bind", code);
         const userUUIDByDB = await ServiceUserGoogle.userUUIDByUnionUUID(userInfo.unionUUID);
         if (userUUIDByDB) {
             throw new ControllerError(ErrorCode.UserAlreadyBinding);


### PR DESCRIPTION
Note: this config changed

```diff
 login:
   google:
-    redirect_uri: https://flat-api-dev.whiteboard.agora.io/v1/login/google/callback
+    redirect_uri:
+      login: https://flat-api-dev.whiteboard.agora.io/v1/login/google/callback
+      bind: https://flat-api-dev.whiteboard.agora.io/v1/user/binding/platform/google
```