### PR TITLE
feat: add admin routes

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -223,3 +223,6 @@ censorship:
       access_id:
       access_secret:
       endpoint:
+
+admin:
+  secret:

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -218,3 +218,6 @@ censorship:
       access_id: test
       access_secret: test
       endpoint: green.cn-shanghai.aliyuncs.com
+
+admin:
+  secret:

--- a/src/constants/Config.ts
+++ b/src/constants/Config.ts
@@ -61,7 +61,7 @@ export const Github = {
 export const Apple = {
     enable: config.login.apple.enable,
     appId: config.apple.app_id,
-    aud: config.login.apple.aud || "io.agora.flat"
+    aud: config.login.apple.aud || "io.agora.flat",
 };
 
 export const AgoraLogin = {
@@ -248,6 +248,10 @@ export const Censorship = {
             endpoint: config.censorship.text.aliCloud.endpoint,
         },
     },
+};
+
+export const Admin = {
+    secret: config.admin?.secret || "",
 };
 
 export const MetricsConfig = {

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -37,7 +37,7 @@ export class MetricsSever {
             void res.type("text/plain").send(await client.metrics());
         });
         if (this.params.port !== 0) {
-            metricsServer.listen(this.params.port, "0.0.0.0", (err, address) => {
+            metricsServer.listen({ host: "0.0.0.0", port: this.params.port }, (err, address) => {
                 if (err) {
                     loggerServer.error("metrics server launch failed", parseError(err));
                     process.exit(1);

--- a/src/plugins/fastify/authenticate.ts
+++ b/src/plugins/fastify/authenticate.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from "fastify/types/instance";
 import jwt from "@fastify/jwt";
-import { JWT, Server } from "../../constants/Config";
+import { Admin, JWT, Server } from "../../constants/Config";
 import { Algorithm } from "fast-jwt";
 import { FastifyReply, FastifyRequest } from "fastify";
 import { loggerServer, parseError } from "../../logger";
@@ -28,6 +28,27 @@ const plugin = async (instance: FastifyInstance, _opts: any): Promise<void> => {
                 void reply.send({
                     status: Status.Failed,
                     code: ErrorCode.JWTSignFailed,
+                });
+
+                return;
+            }
+        },
+    );
+
+    instance.decorate(
+        "authenticateAdmin",
+        async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+            const adminSecret = request.headers["x-flat-secret"];
+            if (!Admin.secret || Admin.secret !== adminSecret) {
+                const reason = !Admin.secret
+                    ? "not enabled on server"
+                    : !adminSecret
+                    ? "missing secret"
+                    : "secret mismatch";
+                loggerServer.warn("admin secret verify failed: " + reason);
+                void reply.code(401).send({
+                    status: Status.Failed,
+                    code: ErrorCode.NotPermission,
                 });
 
                 return;

--- a/src/thirdPartyService/RedisService.ts
+++ b/src/thirdPartyService/RedisService.ts
@@ -159,6 +159,18 @@ class RedisService {
 
         return result;
     }
+
+    public async zadd(key: string, value: string, score: number, expire?: number): Promise<void> {
+        await this.client.zadd(key, score, value);
+
+        if (expire) {
+            await this.client.expire(key, expire);
+        }
+    }
+
+    public async zcard(key: string): Promise<number> {
+        return await this.client.zcard(key);
+    }
 }
 
 export default new RedisService();

--- a/src/utils/ParseConfig.ts
+++ b/src/utils/ParseConfig.ts
@@ -252,6 +252,9 @@ type Config = {
             };
         };
     };
+    admin: {
+        secret: string;
+    };
 };
 
 interface SMSConfig {

--- a/src/utils/Redis.ts
+++ b/src/utils/Redis.ts
@@ -57,4 +57,6 @@ export const RedisKey = {
 
     emailRegisterOrReset: (email: string): string => `email:register:${email}`,
     emailTryRegisterOrResetCount: (email: string): string => `email:count:register:${email}`,
+
+    online: (roomUUID: string): string => `online:${roomUUID}`,
 };

--- a/src/utils/registryRoutersV2.ts
+++ b/src/utils/registryRoutersV2.ts
@@ -15,6 +15,7 @@ const registerRouters =
                 handler: (req: FastifyRequestTypebox<S>, reply: FastifyReply) => Promise<any>,
                 config: {
                     auth?: boolean;
+                    admin?: boolean;
                     schema: S;
                     autoHandle?: boolean;
                     enable?: boolean;
@@ -22,6 +23,7 @@ const registerRouters =
             ) => {
                 const autoHandle = config.autoHandle === undefined || config.autoHandle;
                 const auth = config.auth === undefined || config.auth;
+                const admin = !!config.admin;
                 const enable = config.enable === undefined || config.enable;
 
                 if (!enable) {
@@ -31,7 +33,10 @@ const registerRouters =
                 fastifyServer[method](
                     `/${version}/${path}`,
                     {
-                        preValidation: auth ? [(fastifyServer as any).authenticate] : undefined,
+                        preValidation: [
+                            auth && (fastifyServer as any).authenticate,
+                            admin && (fastifyServer as any).authenticateAdmin,
+                        ].filter(Boolean),
                         schema: config.schema,
                     },
                     async (req, reply: FastifyReply) => {
@@ -112,6 +117,7 @@ interface R<O> {
         ) => Promise<O extends false ? void : Response>,
         config: {
             auth?: boolean;
+            admin?: boolean;
             schema: S;
             autoHandle?: O;
         },

--- a/src/v1/controller/room/updateStatus/Stopped.ts
+++ b/src/v1/controller/room/updateStatus/Stopped.ts
@@ -193,7 +193,7 @@ interface RequestType {
 
 interface ResponseType {}
 
-const readyRecycleInviteCode = async (roomUUID: string): Promise<void> => {
+export const readyRecycleInviteCode = async (roomUUID: string): Promise<void> => {
     // prevent access to new rooms with the previous invitation code
     // add delays and improve security.
     const tenDay = 60 * 60 * 24 * 10;

--- a/src/v1/service/Periodic.ts
+++ b/src/v1/service/Periodic.ts
@@ -7,10 +7,15 @@ import { whiteboardCreateRoom } from "../utils/request/whiteboard/WhiteboardRequ
 import cryptoRandomString from "crypto-random-string";
 import { Region } from "../../constants/Project";
 
+export type NextPeriodicRoomInfo = Pick<
+    RoomPeriodicModel,
+    "begin_time" | "end_time" | "fake_room_uuid"
+>;
+
 export const getNextPeriodicRoomInfo = async (
     periodicUUID: string,
     beginTime: Date,
-): Promise<Pick<RoomPeriodicModel, "begin_time" | "end_time" | "fake_room_uuid"> | undefined> => {
+): Promise<NextPeriodicRoomInfo | undefined> => {
     return await RoomPeriodicDAO().findOne(
         ["begin_time", "end_time", "fake_room_uuid"],
         {

--- a/src/v1/utils/request/agora/RTM.ts
+++ b/src/v1/utils/request/agora/RTM.ts
@@ -1,0 +1,37 @@
+import { Agora } from "../../../../constants/Config";
+import { ax } from "../../Axios";
+
+const baseUrl = `https://api.agora.io/dev/v2/project/${Agora.appId}`;
+
+export interface SendChannelMessageResult {
+    code: "message_sent";
+    request_id: string;
+    result: "success" | "failed";
+}
+
+// https://docs.agora.io/en/signaling/reference/restful-messaging?platform=web#sends-channel-message-api-post
+export const agoraSendChannelMessage = async (
+    uid: string,
+    token: string,
+    channel: string,
+    payload: string,
+): Promise<SendChannelMessageResult> => {
+    const headers = {
+        "x-agora-uid": uid,
+        "x-agora-token": token,
+    };
+
+    const response = await ax.post(
+        `${baseUrl}/rtm/users/${uid}/channel_messages`,
+        {
+            channel_name: channel,
+            enable_historical_messaging: false,
+            payload,
+        },
+        {
+            headers,
+        },
+    );
+
+    return response.data;
+};

--- a/src/v2/__tests__/helpers/api/index.ts
+++ b/src/v2/__tests__/helpers/api/index.ts
@@ -106,4 +106,15 @@ export class HelperAPI {
             },
         });
     }
+
+    public async injectAdmin(secret: string, opts: InjectOptions): Promise<LightMyRequestResponse> {
+        await this.registerPlugin;
+        return await this.app.inject({
+            ...opts,
+            headers: {
+                ...opts.headers,
+                "x-flat-secret": secret,
+            },
+        });
+    }
 }

--- a/src/v2/controllers/admin/ban-rooms.ts
+++ b/src/v2/controllers/admin/ban-rooms.ts
@@ -1,0 +1,20 @@
+import { Type } from "@sinclair/typebox";
+import { FastifyRequestTypebox, Response } from "../../../types/Server";
+import { RoomAdminService } from "../../services/room/admin";
+import { successJSON } from "../internal/utils/response-json";
+
+export const banRoomsSchema = {
+    body: Type.Object({
+        roomUUIDs: Type.Array(Type.String()),
+    }),
+};
+
+export const banRooms = async (
+    req: FastifyRequestTypebox<typeof banRoomsSchema>,
+): Promise<Response> => {
+    const service = new RoomAdminService(req.ids, req.DBTransaction);
+
+    await service.banRooms(req.body.roomUUIDs);
+
+    return successJSON({});
+};

--- a/src/v2/controllers/admin/online.ts
+++ b/src/v2/controllers/admin/online.ts
@@ -1,0 +1,20 @@
+import { Type } from "@sinclair/typebox";
+import { FastifyRequestTypebox, Response } from "../../../types/Server";
+import { RoomAdminService } from "../../services/room/admin";
+import { successJSON } from "../internal/utils/response-json";
+
+export const onlineSchema = {
+    body: Type.Object({
+        roomUUID: Type.String(),
+    }),
+};
+
+export const online = async (
+    req: FastifyRequestTypebox<typeof onlineSchema>,
+): Promise<Response> => {
+    const service = new RoomAdminService(req.ids, req.DBTransaction);
+
+    await service.online(req.body.roomUUID, req.userUUID);
+
+    return successJSON({});
+};

--- a/src/v2/controllers/admin/room-messages.ts
+++ b/src/v2/controllers/admin/room-messages.ts
@@ -1,0 +1,23 @@
+import { Type } from "@sinclair/typebox";
+import { FastifyRequestTypebox, Response } from "../../../types/Server";
+import { RoomAdminService } from "../../services/room/admin";
+import { successJSON } from "../internal/utils/response-json";
+
+export const roomMessagesSchema = {
+    body: Type.Array(
+        Type.Object({
+            roomUUID: Type.String(),
+            message: Type.String(),
+        }),
+    ),
+};
+
+export const roomMessages = async (
+    req: FastifyRequestTypebox<typeof roomMessagesSchema>,
+): Promise<Response> => {
+    const service = new RoomAdminService(req.ids, req.DBTransaction);
+
+    await service.roomMessages(req.body);
+
+    return successJSON({});
+};

--- a/src/v2/controllers/admin/rooms-info.ts
+++ b/src/v2/controllers/admin/rooms-info.ts
@@ -1,0 +1,20 @@
+import { Type } from "@sinclair/typebox";
+import { FastifyRequestTypebox, Response } from "../../../types/Server";
+import { RoomAdminService, RoomsInfo } from "../../services/room/admin";
+import { successJSON } from "../internal/utils/response-json";
+
+export const roomsInfoSchema = {
+    body: Type.Object({
+        UUIDs: Type.Array(Type.String()),
+    }),
+};
+
+export const roomsInfo = async (
+    req: FastifyRequestTypebox<typeof roomsInfoSchema>,
+): Promise<Response<RoomsInfo>> => {
+    const service = new RoomAdminService(req.ids, req.DBTransaction);
+
+    const roomsInfo = await service.roomsInfo(req.body.UUIDs);
+
+    return successJSON(roomsInfo);
+};

--- a/src/v2/controllers/admin/routes.ts
+++ b/src/v2/controllers/admin/routes.ts
@@ -1,0 +1,29 @@
+import { Server } from "../../../utils/registryRoutersV2";
+import { banRooms, banRoomsSchema } from "./ban-rooms";
+import { online, onlineSchema } from "./online";
+import { roomMessages, roomMessagesSchema } from "./room-messages";
+import { roomsInfo, roomsInfoSchema } from "./rooms-info";
+
+export const adminRouters = (server: Server): void => {
+    // /v2/rooms-info and /v2/online do not need admin
+    server.post("rooms-info", roomsInfo, {
+        schema: roomsInfoSchema,
+        auth: false,
+    });
+
+    server.post("online", online, {
+        schema: onlineSchema,
+    });
+
+    server.post("admin/ban-rooms", banRooms, {
+        schema: banRoomsSchema,
+        auth: false,
+        admin: true,
+    });
+
+    server.post("admin/room-messages", roomMessages, {
+        schema: roomMessagesSchema,
+        auth: false,
+        admin: true,
+    });
+};

--- a/src/v2/controllers/routes.ts
+++ b/src/v2/controllers/routes.ts
@@ -9,6 +9,7 @@ import { regionConfigsRouters } from "./configs/region-configs";
 import { registerRouters } from "./register/routes";
 import { loginRouters } from "./login/routes";
 import { resetRouters } from "./reset/routes";
+import { adminRouters } from "./admin/routes";
 
 export const v2Routes = [
     userRouters,
@@ -22,4 +23,5 @@ export const v2Routes = [
     registerRouters,
     loginRouters,
     resetRouters,
+    adminRouters,
 ];

--- a/src/v2/services/room/__tests__/admin.test.ts
+++ b/src/v2/services/room/__tests__/admin.test.ts
@@ -59,6 +59,7 @@ test(`${namespace} - roomsInfo`, async ava => {
 
     ava.deepEqual(roomsInfo, {
         [ordinary[0].roomUUID]: makeResult(ordinary[0]), // idle
+        [periodic[0].periodicUUID]: makeResult(periodic[0]), // idle
         [ordinary_invite]: makeResult(ordinary[1]), // started
         [periodic_invite]: makeResult(periodic[2]), // paused
     });

--- a/src/v2/services/room/__tests__/admin.test.ts
+++ b/src/v2/services/room/__tests__/admin.test.ts
@@ -86,7 +86,7 @@ test(`${namespace} - online`, async ava => {
     await releaseRunner();
 });
 
-test.only(`${namespace} - banRooms`, async ava => {
+test(`${namespace} - banRooms`, async ava => {
     const { t, commitTransaction, releaseRunner } = await useTransaction();
     const { createUser, createRoom } = testService(t);
 

--- a/src/v2/services/room/__tests__/admin.test.ts
+++ b/src/v2/services/room/__tests__/admin.test.ts
@@ -1,0 +1,67 @@
+import RedisService from "../../../../thirdPartyService/RedisService";
+
+import test from "ava";
+import { v4 } from "uuid";
+import { RoomStatus } from "../../../../model/room/Constants";
+import { RedisKey } from "../../../../utils/Redis";
+import { testService } from "../../../__tests__/helpers/db";
+import { useTransaction } from "../../../__tests__/helpers/db/query-runner";
+import { initializeDataSource } from "../../../__tests__/helpers/db/test-hooks";
+import { ids } from "../../../__tests__/helpers/fastify/ids";
+import { RoomAdminService } from "../admin";
+import { pick } from "lodash";
+
+const namespace = "services.room.admin";
+initializeDataSource(test, namespace);
+
+test(`${namespace} - roomsInfo`, async ava => {
+    const { t, commitTransaction, releaseRunner } = await useTransaction();
+    const { createRoom } = testService(t);
+
+    const ordinary = [
+        await createRoom.quick({ roomStatus: RoomStatus.Idle }),
+        await createRoom.quick({ roomStatus: RoomStatus.Started }),
+        await createRoom.quick({ roomStatus: RoomStatus.Paused }),
+        await createRoom.quick({ roomStatus: RoomStatus.Stopped }),
+    ];
+
+    const periodic = [
+        await createRoom.quick({ periodicUUID: v4(), roomStatus: RoomStatus.Idle }),
+        await createRoom.quick({ periodicUUID: v4(), roomStatus: RoomStatus.Started }),
+        await createRoom.quick({ periodicUUID: v4(), roomStatus: RoomStatus.Paused }),
+        await createRoom.quick({ periodicUUID: v4(), roomStatus: RoomStatus.Stopped }),
+    ];
+
+    await commitTransaction();
+
+    const UUIDs: string[] = [];
+    UUIDs.push(ordinary[0].roomUUID); // normal long uuid
+    const ordinary_invite = "1111111111";
+    RedisService.set(RedisKey.roomInviteCode(ordinary_invite), ordinary[1].roomUUID); // started
+    UUIDs.push(ordinary_invite); // invite code in redis
+
+    const periodic_invite = "2222222222";
+    UUIDs.push(periodic[0].periodicUUID); // normal long uuid
+    RedisService.set(RedisKey.roomInviteCode(periodic_invite), periodic[2].roomUUID); // paused
+    UUIDs.push(periodic_invite); // invite code in redis
+
+    UUIDs.push(ordinary[3].roomUUID); // stopped rooms
+    UUIDs.push(periodic[3].roomUUID);
+    UUIDs.push(v4()); // missing uuid
+    UUIDs.push("3333333333"); // missing invite code
+
+    const service = new RoomAdminService(ids(), t);
+    const roomsInfo = await service.roomsInfo(UUIDs);
+
+    const makeResult = (room: typeof ordinary[0]) =>
+        pick(room, ["roomUUID", "periodicUUID", "ownerUUID", "roomStatus"]);
+
+    ava.deepEqual(roomsInfo, {
+        [ordinary[0].roomUUID]: makeResult(ordinary[0]), // idle
+        [ordinary_invite]: makeResult(ordinary[1]), // started
+        [periodic_invite]: makeResult(periodic[2]), // paused
+    });
+    // missing and stopped are not returned
+
+    await releaseRunner();
+});

--- a/src/v2/services/room/admin.ts
+++ b/src/v2/services/room/admin.ts
@@ -1,0 +1,283 @@
+import RedisService from "../../../thirdPartyService/RedisService";
+
+import { EntityManager, Not, In } from "typeorm";
+import { Region } from "../../../constants/Project";
+import { createLoggerService, parseError } from "../../../logger";
+import { PeriodicStatus, RoomStatus } from "../../../model/room/Constants";
+import { RedisKey } from "../../../utils/Redis";
+import { readyRecycleInviteCode } from "../../../v1/controller/room/updateStatus/Stopped";
+import { roomIsRunning } from "../../../v1/controller/room/utils/RoomStatus";
+import { rtcQueue } from "../../../v1/queue";
+import { getNextPeriodicRoomInfo, updateNextPeriodicRoomInfo } from "../../../v1/service/Periodic";
+import { whiteboardBanRoom } from "../../../v1/utils/request/whiteboard/WhiteboardRequest";
+import { roomDAO, roomPeriodicConfigDAO, roomPeriodicDAO } from "../../dao";
+import { getRTMToken } from "../../../v1/utils/AgoraToken";
+import { agoraSendChannelMessage } from "../../../v1/utils/request/agora/RTM";
+
+export class RoomAdminService {
+    private readonly logger = createLoggerService<"roomAdmin">({
+        serviceName: "roomAdmin",
+        ids: this.ids,
+    });
+
+    constructor(private readonly ids: IDS, private readonly DBTransaction: EntityManager) {}
+
+    public async banRooms(roomUUIDs: string[]): Promise<void> {
+        const roomInfo = await roomDAO.find(
+            this.DBTransaction,
+            [
+                "room_uuid",
+                "room_status",
+                "owner_uuid",
+                "periodic_uuid",
+                "whiteboard_room_uuid",
+                "region",
+            ],
+            { room_uuid: In(roomUUIDs) },
+        );
+
+        const runningRooms = roomInfo.filter(room => roomIsRunning(room.room_status));
+        if (runningRooms.length === 0) return;
+
+        roomUUIDs = runningRooms.map(room => room.room_uuid);
+
+        const commands: Promise<unknown>[] = [];
+
+        const endTime = new Date();
+
+        // 1. Stop running rooms
+        commands.push(
+            roomDAO.update(
+                this.DBTransaction,
+                { room_status: RoomStatus.Stopped, end_time: endTime },
+                { room_uuid: In(roomUUIDs) },
+            ),
+        );
+
+        // 2. Make next periodic rooms
+        const periodicRoomInfo = new Map<string, { ownerUUID: string; region: Region }>();
+        for (const { periodic_uuid, owner_uuid, region } of runningRooms) {
+            if (periodic_uuid) {
+                periodicRoomInfo.set(periodic_uuid, { ownerUUID: owner_uuid, region });
+            }
+        }
+
+        const periodicUUIDs = runningRooms.map(room => room.periodic_uuid).filter(Boolean);
+        const periodicRooms =
+            periodicUUIDs.length > 0
+                ? await roomPeriodicDAO.find(this.DBTransaction, ["periodic_uuid", "begin_time"], {
+                      periodic_uuid: In(periodicUUIDs),
+                      fake_room_uuid: In(roomUUIDs),
+                  })
+                : [];
+
+        // New rooms because of closing previous periodic rooms
+        const nextRoomUUIDs: string[] = [];
+        // Stopped rooms
+        const needRecycleInviteCode: string[] = [];
+
+        if (periodicRooms.length > 0) {
+            // 2.1. Stop fake rooms in database
+            commands.push(
+                roomPeriodicDAO.update(
+                    this.DBTransaction,
+                    { room_status: RoomStatus.Stopped, end_time: endTime },
+                    { fake_room_uuid: In(roomUUIDs) },
+                ),
+            );
+
+            // TODO: performance
+            for (const { periodic_uuid, begin_time } of periodicRooms) {
+                const nextPeriodicRoomInfo = await getNextPeriodicRoomInfo(
+                    periodic_uuid,
+                    begin_time,
+                );
+                if (nextPeriodicRoomInfo) {
+                    nextRoomUUIDs.push(nextPeriodicRoomInfo.fake_room_uuid);
+                    const periodicRoomConfig = await roomPeriodicConfigDAO.findOne(
+                        this.DBTransaction,
+                        ["title", "room_type"],
+                        { periodic_uuid },
+                    );
+                    const info = periodicRoomInfo.get(periodic_uuid);
+                    if (periodicRoomConfig && info) {
+                        const { title, room_type } = periodicRoomConfig;
+                        // 2.2. Create next room and transfer users
+                        commands.push(
+                            ...(await updateNextPeriodicRoomInfo({
+                                transaction: this.DBTransaction,
+                                periodic_uuid,
+                                user_uuid: info.ownerUUID,
+                                title,
+                                room_type,
+                                region: info.region,
+                                ...nextPeriodicRoomInfo,
+                            })),
+                        );
+                    }
+                } else {
+                    needRecycleInviteCode.push(periodic_uuid);
+                }
+            }
+
+            // 2.3 Now `needRecycleInviteCode` only includes stopped PERIODIC rooms
+            // Stop them in the config database
+            if (needRecycleInviteCode.length > 0) {
+                commands.push(
+                    roomPeriodicConfigDAO.update(
+                        this.DBTransaction,
+                        { periodic_status: PeriodicStatus.Stopped },
+                        { periodic_uuid: In(needRecycleInviteCode.slice()) },
+                    ),
+                );
+            }
+        }
+
+        // Add stopped NORMAL rooms to `needRecycleInviteCode` too
+        for (const room of runningRooms) {
+            if (room.periodic_uuid) continue;
+            needRecycleInviteCode.push(room.room_uuid);
+        }
+
+        await Promise.all(commands);
+
+        // 4. Ban whiteboard room
+        for (const { region, whiteboard_room_uuid } of runningRooms) {
+            whiteboardBanRoom(region, whiteboard_room_uuid).catch(error => {
+                this.logger.warn("ban room failed!", parseError(error));
+            });
+        }
+
+        // 5. Recycle invite code for stopped rooms
+        for (const roomUUID of needRecycleInviteCode) {
+            readyRecycleInviteCode(roomUUID);
+        }
+
+        // 6. Start observing new rooms
+        for (const nextRoomUUID of nextRoomUUIDs) {
+            rtcQueue(nextRoomUUID);
+        }
+    }
+
+    public async roomsInfo(UUIDs: string[]): Promise<RoomsInfo> {
+        const result: Record<string, Partial<RoomInfo>> = {};
+        const uuidKeyMap: Record<string, string> = {};
+
+        // Prepare to search long uuid from redis
+        const inviteCodes: string[] = [];
+        for (const uuid of UUIDs) {
+            result[uuid] = {};
+            uuidKeyMap[uuid] = uuid;
+            if (this.isInviteCode(uuid)) {
+                inviteCodes.push(uuid);
+            } else {
+                result[uuid].roomUUID = uuid;
+            }
+        }
+
+        if (inviteCodes.length > 0) {
+            try {
+                const roomUUIDs = await RedisService.mget(inviteCodes.map(RedisKey.roomInviteCode));
+                for (let index = inviteCodes.length - 1; index >= 0; --index) {
+                    const uuid = inviteCodes[index];
+                    const roomUUID = roomUUIDs[index];
+                    if (roomUUID) {
+                        result[uuid].roomUUID = roomUUID;
+                        uuidKeyMap[roomUUID] = uuid;
+                    }
+                }
+            } catch (error) {
+                this.logger.error("get room uuid by invite code failed", parseError(error));
+            }
+        }
+
+        const roomUUIDs = Object.values(result)
+            .map(room => room.roomUUID)
+            .filter(Boolean) as string[];
+
+        const ordinaryRooms = await roomDAO.find(
+            this.DBTransaction,
+            ["room_uuid", "periodic_uuid", "owner_uuid", "room_status"],
+            { room_uuid: In(roomUUIDs), periodic_uuid: "" },
+        );
+
+        for (const room of ordinaryRooms) {
+            const key = uuidKeyMap[room.room_uuid];
+            const ret = result[key];
+            if (ret) {
+                ret.roomUUID = room.room_uuid;
+                ret.periodicUUID = room.periodic_uuid;
+                ret.ownerUUID = room.owner_uuid;
+                ret.roomStatus = room.room_status;
+            }
+        }
+
+        const periodicRooms = await roomDAO.find(
+            this.DBTransaction,
+            ["room_uuid", "periodic_uuid", "owner_uuid", "room_status"],
+            { periodic_uuid: In(roomUUIDs), room_status: Not(In([RoomStatus.Stopped])) },
+        );
+
+        for (const room of periodicRooms) {
+            const key = uuidKeyMap[room.room_uuid];
+            const ret = result[key];
+            if (ret) {
+                ret.roomUUID = room.room_uuid;
+                ret.periodicUUID = room.periodic_uuid;
+                ret.ownerUUID = room.owner_uuid;
+                ret.roomStatus = room.room_status;
+            }
+        }
+
+        // Clean not found rooms
+        for (const uuid of UUIDs) {
+            if (!result[uuid].roomUUID) {
+                delete result[uuid];
+            }
+        }
+
+        return result as RoomsInfo;
+    }
+
+    public async roomMessages(messages: { roomUUID: string; message: string }[]): Promise<void> {
+        const agoraUID = "flat-server";
+        const agoraToken = await getRTMToken(agoraUID);
+        for (const { roomUUID, message } of messages) {
+            try {
+                const response = await agoraSendChannelMessage(
+                    agoraUID,
+                    agoraToken,
+                    roomUUID,
+                    message,
+                );
+                if (response.result !== "success") {
+                    this.logger.warn("send rtm message " + response.result, {
+                        errorMessage: [response.request_id, roomUUID, message].join(":"),
+                    });
+                }
+            } catch (error) {
+                this.logger.warn("failed to send rtm message", parseError(error));
+            }
+        }
+    }
+
+    public async online(roomUUID: string, userUUID: string): Promise<void> {
+        const oneDay = 60 * 60 * 24;
+        await RedisService.zadd(RedisKey.online(roomUUID), userUUID, Date.now(), oneDay);
+    }
+
+    private isInviteCode(uuid: string): boolean {
+        return /^\d{10,11}$/.test(uuid);
+    }
+}
+
+export interface RoomInfo {
+    roomUUID: string;
+    periodicUUID: string;
+    ownerUUID: string;
+    roomStatus: RoomStatus;
+}
+
+export interface RoomsInfo {
+    [uuid: string]: RoomInfo;
+}

--- a/src/v2/services/room/admin.ts
+++ b/src/v2/services/room/admin.ts
@@ -198,7 +198,7 @@ export class RoomAdminService {
         const ordinaryRooms = await roomDAO.find(
             this.DBTransaction,
             ["room_uuid", "periodic_uuid", "owner_uuid", "room_status"],
-            { room_uuid: In(roomUUIDs), periodic_uuid: "" },
+            { room_uuid: In(roomUUIDs), room_status: Not(In([RoomStatus.Stopped])) },
         );
 
         for (const room of ordinaryRooms) {
@@ -231,7 +231,7 @@ export class RoomAdminService {
 
         // Clean not found rooms
         for (const uuid of UUIDs) {
-            if (!result[uuid].roomUUID) {
+            if (!result[uuid].roomStatus) {
                 delete result[uuid];
             }
         }

--- a/src/v2/services/room/admin.ts
+++ b/src/v2/services/room/admin.ts
@@ -219,7 +219,7 @@ export class RoomAdminService {
         );
 
         for (const room of periodicRooms) {
-            const key = uuidKeyMap[room.room_uuid];
+            const key = uuidKeyMap[room.periodic_uuid];
             const ret = result[key];
             if (ret) {
                 ret.roomUUID = room.room_uuid;


### PR DESCRIPTION
Add a new config `admin.secret: string` to auth admin routes.

To pass the auth, put an `x-flat-secret` header in the request, which should be the same string as the config above.

New routes:

### Get rooms info (no sensitive data)

This route does not need auth and admin.

```js
POST /v2/rooms-info { "UUIDs": ["1234567890"] } =>
{
  "1234567890": {
    "roomUUID": "a192f15c-27e7-4b92-a4b6-6725a0321fb8",
    "periodicUUID": "",
    "ownerUUID": "0f4ea023-ecfd-4147-bcf3-7258b14ceeb8",
    "roomStatus": "Idle"
  }
}
```

### Notify online

Requires auth.

```js
POST /v2/online { "roomUUID": "a192f15c-27e7-4b92-a4b6-6725a0321fb8" } => {}
```

### Ban rooms

Requires admin.

```js
POST /v2/admin/ban-rooms { "roomUUIDs": ["a192f15c-27e7-4b92-a4b6-6725a0321fb8"] } => {}
```

### Send RTM messages

Requires admin. The senderID will always be `flat-server`.

```js
POST /v2/admin/room-messages [{ "roomUUID": "a192f15c-27e7-4b92-a4b6-6725a0321fb8", "message": "hello" }] => {}
```