### PR TITLE
Add optional `convertType` para for cloud file upload

### DIFF
--- a/src/v2/controllers/cloud-storage/upload/start.ts
+++ b/src/v2/controllers/cloud-storage/upload/start.ts
@@ -5,6 +5,7 @@ import { successJSON } from "../../internal/utils/response-json";
 import { CloudStorageUploadService } from "../../../services/cloud-storage/upload";
 import { uploadStartReturnSchema } from "../../../services/cloud-storage/upload.schema";
 import { useOnceService } from "../../../service-locator";
+import { FileResourceType } from "../../../../model/cloudStorage/Constants";
 
 export const cloudStorageUploadStartSchema = {
     body: Type.Object(
@@ -23,6 +24,7 @@ export const cloudStorageUploadStartSchema = {
                 minLength: 1,
                 format: "directory-path",
             }),
+            convertType: Type.Optional(Type.Enum(FileResourceType)),
         },
         {
             additionalProperties: false,
@@ -46,6 +48,7 @@ export const cloudStorageUploadStart = async (
         fileName: req.body.fileName,
         fileSize: req.body.fileSize,
         targetDirectoryPath: req.body.targetDirectoryPath,
+        convertType: req.body.convertType,
     });
 
     return successJSON(result);

--- a/src/v2/services/cloud-storage/__tests__/upload.test.ts
+++ b/src/v2/services/cloud-storage/__tests__/upload.test.ts
@@ -396,18 +396,60 @@ test.serial(`${namespace} - finish`, async ava => {
     await releaseRunner();
 });
 
-test.serial(`${namespace} - start`, async ava => {
+test.serial(`${namespace} - start use projector`, async ava => {
     const { t, releaseRunner } = await useTransaction();
 
-    const [userUUID, fileName, targetDirectoryPath, fileSize] = [v4(), `${v4()}.pptx`, "/", 20];
+    const [userUUID, fileName, targetDirectoryPath, fileSize, convertType] = [
+        v4(),
+        `${v4()}.ppt`,
+        "/",
+        20,
+        FileResourceType.WhiteboardProjector,
+    ];
 
     const result = await new CloudStorageUploadService(ids(), t, userUUID).start({
         targetDirectoryPath,
         fileName,
         fileSize,
+        convertType,
     });
 
     ava.is(Schema.check(uploadStartReturnSchema, result), null);
+
+    const resourceType = await RedisService.hmget(
+        RedisKey.cloudStorageFileInfo(userUUID, result.fileUUID),
+        "fileResourceType",
+    );
+    ava.is(resourceType, FileResourceType.WhiteboardConvert);
+
+    await releaseRunner();
+});
+
+test.serial(`${namespace} - start allowWhiteboardConvert`, async ava => {
+    const { t, releaseRunner } = await useTransaction();
+
+    const [userUUID, fileName, targetDirectoryPath, fileSize, convertType] = [
+        v4(),
+        `${v4()}.ppt`,
+        "/",
+        20,
+        undefined,
+    ];
+
+    const result = await new CloudStorageUploadService(ids(), t, userUUID).start({
+        targetDirectoryPath,
+        fileName,
+        fileSize,
+        convertType,
+    });
+
+    ava.is(Schema.check(uploadStartReturnSchema, result), null);
+
+    const resourceType = await RedisService.hmget(
+        RedisKey.cloudStorageFileInfo(userUUID, result.fileUUID),
+        "fileResourceType",
+    );
+    ava.is(resourceType, FileResourceType.WhiteboardProjector);
 
     await releaseRunner();
 });

--- a/src/v2/services/cloud-storage/file.ts
+++ b/src/v2/services/cloud-storage/file.ts
@@ -74,7 +74,7 @@ export class CloudStorageFileService {
         }
     }
 
-    public getFileResourceTypeByFileName(fileName: string): FileResourceType {
+    public getFileResourceTypeByFileNameUseProjector(fileName: string): FileResourceType {
         const extname = path.extname(fileName).toLowerCase();
         switch (extname) {
             case ".pptx":
@@ -83,6 +83,36 @@ export class CloudStorageFileService {
             case ".ppt":
             case ".pdf": {
                 return FileResourceType.WhiteboardProjector;
+            }
+            case ".png":
+            case ".jpg":
+            case ".jpeg":
+            case ".gif":
+            case ".mp3":
+            case ".mp4": {
+                return FileResourceType.NormalResources;
+            }
+            default: {
+                this.logger.warn("fileName extname is not preset", {
+                    cloudStorageFile: {
+                        fileName,
+                    },
+                });
+                throw new FError(ErrorCode.ParamsCheckFailed);
+            }
+        }
+    }
+
+    public getFileResourceTypeByFileName(fileName: string): FileResourceType {
+        const extname = path.extname(fileName).toLowerCase();
+        switch (extname) {
+            case ".pptx":
+                return FileResourceType.WhiteboardProjector;
+            case ".doc":
+            case ".docx":
+            case ".ppt":
+            case ".pdf": {
+                return FileResourceType.WhiteboardConvert;
             }
             case ".png":
             case ".jpg":

--- a/src/v2/services/cloud-storage/upload.ts
+++ b/src/v2/services/cloud-storage/upload.ts
@@ -46,7 +46,7 @@ export class CloudStorageUploadService {
     public async start(
         config: CloudStorageUploadStartConfig,
     ): Promise<CloudStorageUploadStartReturn> {
-        const { fileName, fileSize, targetDirectoryPath } = config;
+        const { fileName, fileSize, targetDirectoryPath, convertType } = config;
         await this.assertConcurrentLimit();
         await this.assertConcurrentFileSize(await this.getTotalUsageByUpdated(fileSize));
         await new CloudStorageDirectoryService(
@@ -55,11 +55,15 @@ export class CloudStorageUploadService {
             this.userUUID,
         ).assertExists(targetDirectoryPath);
 
-        const fileResourceType = new CloudStorageFileService(
+        const fileService = new CloudStorageFileService(
             this.ids,
             this.DBTransaction,
             this.userUUID,
-        ).getFileResourceTypeByFileName(fileName);
+        );
+        const fileResourceType =
+            convertType === FileResourceType.WhiteboardProjector
+                ? fileService.getFileResourceTypeByFileNameUseProjector(fileName)
+                : fileService.getFileResourceTypeByFileName(fileName);
 
         const fileUUID = v4();
         await RedisService.hmset(

--- a/src/v2/services/cloud-storage/upload.type.ts
+++ b/src/v2/services/cloud-storage/upload.type.ts
@@ -4,6 +4,7 @@ export interface CloudStorageUploadStartConfig {
     fileName: string;
     fileSize: number;
     targetDirectoryPath: string;
+    convertType?: FileResourceType;
 }
 
 export interface CloudStorageUploadStartReturn {


### PR DESCRIPTION
- Add parameter `excludeWhiteboardConvert` for cloud file upload
- Update upload test

All new front end should add parameter `convertType = "WhiteboardProjector"` to the upload request.